### PR TITLE
Readme file fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 2. Install the Angular CLI. To get help on the Angular CLI check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
-3. Download the ZIP for this repository, extract into a project folder under wherever NPM and the Angular CLI are installed.
+3. Download the ZIP for this repository, extract into a project folder under wherever NPM and the Angular CLI are installed. *IMPORTANT*: the project folder extracts as 'pulsar-master', you must remove '-master' from the name of the directory so it reads only as 'pulsar'; the app will not run otherwise.
 
 4. In the terminal cd to the pulsar directory, run `npm install` to install the project dependencies. Then run `ng serve --open`, the app should automatically launch in the browser at `http://localhost:4200/`.
 


### PR DESCRIPTION
Not sure why the name of the branch is included in the unzipped folder name, but with Angular the folder name of a project CANNOT be changed without also updating a few other files and reinstalling node modules.